### PR TITLE
projects.md &active=1 typo

### DIFF
--- a/Sections/projects.md
+++ b/Sections/projects.md
@@ -51,7 +51,7 @@ A sample response:
 
 To access projects that are **archived** add the query string: `&active=0`.
 
-Use: `&active=1` to view all **archived** projects.
+Use: `&active=1` to view all **active** projects.
 
 Get Project
 -----------


### PR DESCRIPTION
There's a typo in the projects API doc. Implies &active=1 will return all archived projects when it actually returns active projects.